### PR TITLE
Add CCSIG and BitSIG in readme channel

### DIFF
--- a/messages/readme.xml
+++ b/messages/readme.xml
@@ -89,6 +89,20 @@ Artificial Intelligence
 • [Website](https://edinburghai.org/)
       ]]></content>
     </field>
+    <field inline="true">
+      <title>CCSIG</title>
+      <content><![CDATA[
+Competitive Programming
+• [Join Discord!](https://discord.gg/AnAHaEE8jD)
+• [Website](https://ccsig.comp-soc.com/)
+      ]]></content>
+    </field>
+    <field inline="true">
+      <title>BitSIG</title>
+      <content><![CDATA[
+• [Join Discord!](https://discord.gg/FQuQZHnx4r)
+      ]]></content>
+    </field>
     <field>
       <title> </title>
       <content><![CDATA[


### PR DESCRIPTION
Left BitSIG description empty as the one on the website might be too long