### PR TITLE
Fix Watchtower CI using an outdated header for tokens (broken since 2020)

### DIFF
--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -34,4 +34,4 @@ jobs:
           docker push $IMAGE_ID:latest
       - name: Trigger update
         run: |
-          curl -H "Token: ${{ secrets.WATCHTOWER_TOKEN }}" https://watchtower.dev.comp-soc.com/v1/update
+          curl -H "Authorization: Bearer ${{ secrets.WATCHTOWER_TOKEN }}" https://watchtower.dev.comp-soc.com/v1/update


### PR DESCRIPTION
Watchtower was recently updated on the CompSoc DO server from a version released in early 2020 (or even 2019) to a maintained fork last updated 5 days ago. Along with some service downtimes, this also changed how we should use the update endpoint for Watchtower.

This PR fixes it to match what the update changed: use the Authorization HTTP header instead of the Token header.